### PR TITLE
optimizer.fit correction in 7_kod.ipynb

### DIFF
--- a/7_kod.ipynb
+++ b/7_kod.ipynb
@@ -2815,7 +2815,7 @@
     "                         cv=10, \n",
     "                         n_jobs=-1)\n",
     "\n",
-    "optimizer.fit(X_train_f, y_train)"
+    "optimizer.fit(X_train_r, y_train)"
    ]
   },
   {


### PR DESCRIPTION
W przypadku regresji logistycznej, ze względu na kopiuj-wklej z drzewa regresji, optimizer.fit używał danych z one-hot encoding a nie zestandaryzowanych. Stąd te problemy ze zbieżnością.